### PR TITLE
카메라 정보 설정 시 배경 이미지 선택 ui 변경.

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,20 +13,6 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="testUriToBitmap()">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="getPatientData success()">
-        <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-10-06T10:24:43.736280400Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\hoijun\.android\avd\Medium_Phone_API_34.avd" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/main/java/com/example/patientManageApp/presentation/screen/main/settingCameraPage/SettingCameraScreen.kt
+++ b/app/src/main/java/com/example/patientManageApp/presentation/screen/main/settingCameraPage/SettingCameraScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -325,8 +326,8 @@ private fun WarningText() {
 private fun BackGroundField(backGroundImg: String, clickBackGroundImg: (selectedImg: Int) -> Unit) {
     val configuration = LocalConfiguration.current
     val screenWidth = configuration.screenWidthDp.dp
-    val imageSize = (screenWidth - 70.dp) / 2
-    Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 20.dp))
+    val imageSize = (screenWidth - 70.dp) / 4
+    Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp))
     {
         Text(text = "배경 이미지 선택",
             fontSize = 15.sp,
@@ -346,14 +347,6 @@ private fun BackGroundField(backGroundImg: String, clickBackGroundImg: (selected
                 isSelected = getBackGroundImage(R.drawable.bed_room) == backGroundImg,
                 size = imageSize
             ) { clickBackGroundImg(it) }
-        }
-
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier
-                .padding(top = 20.dp)
-                .fillMaxWidth()
-        ) {
             BackGroundImage(
                 resourceId = R.drawable.my_room,
                 isSelected = getBackGroundImage(R.drawable.my_room) == backGroundImg,
@@ -381,7 +374,7 @@ private fun BackGroundImage(
         modifier = Modifier
             .clip(RoundedCornerShape(15.dp))
             .border(
-                5.dp,
+                3.dp,
                 Color(0xFFc0c2c4),
                 RoundedCornerShape(15.dp)
             )


### PR DESCRIPTION
안내 문구 추가 때문에 화면에서 저장 버튼이 보이지 않아서, 배경 이미지 선택 ui를 2 * 2의 형태에서 1 * 4의 형태로 변경.